### PR TITLE
Add manual page with jira and qtest integration

### DIFF
--- a/MANUAL_PAGE_API_DOCUMENTATION.md
+++ b/MANUAL_PAGE_API_DOCUMENTATION.md
@@ -1,0 +1,376 @@
+# Manual Page Feature - API Documentation
+
+## Overview
+
+The Manual Page feature extends the QA Automation Coverage Dashboard with Jira integration capabilities. It allows teams to:
+
+- Fetch Jira issues from specific sprints
+- Link QTest test cases to Jira issues
+- Mark test cases as automatable or non-automatable
+- Automatically integrate with the Test Case Service for automation readiness
+- Search for keywords in Jira issue comments
+
+## Configuration
+
+### Prerequisites
+
+1. **Jira Server/Cloud Access**: You need access to a Jira instance with:
+   - Valid username and API token/password
+   - Board ID and Project Key
+   - Proper permissions to read issues and comments
+
+2. **Jira Configuration**: Update your `application.properties` file:
+
+```properties
+# Jira Configuration
+jira.url=https://your-jira-instance.atlassian.net
+jira.username=your-email@company.com
+jira.token=your-jira-api-token
+jira.project.key=PROJECT_KEY
+jira.board.id=123
+```
+
+### Getting Jira API Token
+
+1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+2. Create an API token
+3. Copy the token and use it in the configuration
+
+### Finding Board ID
+
+1. Go to your Jira board
+2. Look at the URL: `https://your-jira.atlassian.net/jira/software/projects/PROJECT/boards/123`
+3. The number `123` is your board ID
+
+## API Endpoints
+
+### Base URL: `/api/manual-page`
+
+### 1. Test Connection
+
+Test if the Jira configuration is working.
+
+**GET** `/test-connection`
+
+**Response:**
+```json
+{
+  "connected": true,
+  "message": "Successfully connected to Jira"
+}
+```
+
+### 2. Get Available Sprints
+
+Fetch all sprints from the configured Jira board.
+
+**GET** `/sprints`
+
+**Response:**
+```json
+[
+  {
+    "id": "123",
+    "name": "Sprint 1",
+    "state": "ACTIVE",
+    "startDate": "2024-01-01T00:00:00.000Z",
+    "endDate": "2024-01-14T00:00:00.000Z"
+  },
+  {
+    "id": "124",
+    "name": "Sprint 2",
+    "state": "FUTURE",
+    "startDate": "2024-01-15T00:00:00.000Z",
+    "endDate": "2024-01-28T00:00:00.000Z"
+  }
+]
+```
+
+### 3. Sync Sprint Issues
+
+Fetch issues from Jira and sync them with the local database.
+
+**POST** `/sprints/{sprintId}/sync`
+
+**Response:**
+```json
+[
+  {
+    "id": 1,
+    "jiraKey": "PROJECT-123",
+    "summary": "Implement user login feature",
+    "description": "As a user, I want to log in...",
+    "assignee": "john.doe",
+    "assigneeDisplayName": "John Doe",
+    "sprintId": "123",
+    "sprintName": "Sprint 1",
+    "issueType": "Story",
+    "status": "In Progress",
+    "priority": "High",
+    "keywordCount": 0,
+    "linkedTestCases": [
+      {
+        "id": 1,
+        "qtestTitle": "Test login with valid credentials",
+        "canBeAutomated": false,
+        "cannotBeAutomated": false,
+        "automationStatus": "PENDING"
+      }
+    ]
+  }
+]
+```
+
+### 4. Get Sprint Issues
+
+Get previously synced issues for a sprint from the local database.
+
+**GET** `/sprints/{sprintId}/issues`
+
+**Response:** Same as sync endpoint
+
+### 5. Update Test Case Automation Flags
+
+Mark test cases as automatable or non-automatable.
+
+**PUT** `/test-cases/{testCaseId}/automation-flags`
+
+**Request Body:**
+```json
+{
+  "canBeAutomated": true,
+  "cannotBeAutomated": false
+}
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "qtestTitle": "Test login with valid credentials",
+  "canBeAutomated": true,
+  "cannotBeAutomated": false,
+  "automationStatus": "READY_TO_AUTOMATE",
+  "projectId": 1,
+  "projectName": "Web Application",
+  "assignedTesterId": 1,
+  "assignedTesterName": "Jane Smith"
+}
+```
+
+### 6. Map Test Case to Project and Tester
+
+Assign test cases to projects and testers.
+
+**PUT** `/test-cases/{testCaseId}/mapping`
+
+**Request Body:**
+```json
+{
+  "projectId": 1,
+  "testerId": 2
+}
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "qtestTitle": "Test login with valid credentials",
+  "projectId": 1,
+  "projectName": "Web Application",
+  "assignedTesterId": 2,
+  "assignedTesterName": "Jane Smith",
+  "domainMapped": "Authentication"
+}
+```
+
+### 7. Search Keywords in Comments
+
+Search for specific keywords in Jira issue comments.
+
+**POST** `/issues/{jiraKey}/keyword-search`
+
+**Request Body:**
+```json
+{
+  "keyword": "observation"
+}
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "jiraKey": "PROJECT-123",
+  "summary": "Implement user login feature",
+  "keywordCount": 3,
+  "searchKeyword": "observation",
+  "linkedTestCases": [...]
+}
+```
+
+### 8. Get Sprint Automation Statistics
+
+Get automation readiness statistics for a sprint.
+
+**GET** `/sprints/{sprintId}/statistics`
+
+**Response:**
+```json
+{
+  "totalTestCases": 25,
+  "readyToAutomate": 10,
+  "notAutomatable": 5,
+  "pending": 10,
+  "projectBreakdown": {
+    "Web Application": {
+      "READY_TO_AUTOMATE": 6,
+      "NOT_AUTOMATABLE": 2,
+      "PENDING": 4
+    },
+    "Mobile App": {
+      "READY_TO_AUTOMATE": 4,
+      "NOT_AUTOMATABLE": 3,
+      "PENDING": 6
+    }
+  }
+}
+```
+
+### 9. Get Projects and Testers
+
+Get available projects and testers for mapping.
+
+**GET** `/projects`
+```json
+[
+  {
+    "id": 1,
+    "name": "Web Application",
+    "description": "Main web application",
+    "domain": {
+      "id": 1,
+      "name": "Authentication"
+    }
+  }
+]
+```
+
+**GET** `/testers`
+```json
+[
+  {
+    "id": 1,
+    "name": "Jane Smith",
+    "email": "jane.smith@company.com",
+    "role": "Senior QA Engineer"
+  }
+]
+```
+
+## Automation Readiness Flow
+
+When a test case is marked as "Can be Automated" (and "Cannot be Automated" is false), the system automatically:
+
+1. **Validates Mapping**: Checks if the test case has both project and tester assignments
+2. **Creates TestCase**: Creates or updates a corresponding `TestCase` entity in the automation system
+3. **Sets Status**: Marks the test case as "READY_TO_AUTOMATE"
+4. **Assigns Resources**: Links it to the specified project and tester
+
+## Database Schema
+
+### JiraIssue Table
+```sql
+CREATE TABLE jira_issues (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    jira_key VARCHAR(50) UNIQUE NOT NULL,
+    summary VARCHAR(500) NOT NULL,
+    description TEXT,
+    assignee VARCHAR(100),
+    assignee_display_name VARCHAR(100),
+    sprint_id VARCHAR(50),
+    sprint_name VARCHAR(100),
+    issue_type VARCHAR(50),
+    status VARCHAR(50),
+    priority VARCHAR(50),
+    keyword_count INT DEFAULT 0,
+    search_keyword VARCHAR(100),
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
+);
+```
+
+### JiraTestCase Table
+```sql
+CREATE TABLE jira_test_cases (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    qtest_title VARCHAR(500) NOT NULL,
+    qtest_id VARCHAR(100),
+    can_be_automated BOOLEAN DEFAULT FALSE,
+    cannot_be_automated BOOLEAN DEFAULT FALSE,
+    automation_status VARCHAR(50),
+    assigned_tester_id BIGINT,
+    jira_issue_id BIGINT NOT NULL,
+    project_id BIGINT,
+    tester_id BIGINT,
+    domain_mapped VARCHAR(100),
+    notes TEXT,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    FOREIGN KEY (jira_issue_id) REFERENCES jira_issues(id),
+    FOREIGN KEY (project_id) REFERENCES projects(id),
+    FOREIGN KEY (tester_id) REFERENCES testers(id)
+);
+```
+
+## Error Handling
+
+All endpoints return appropriate HTTP status codes:
+
+- **200 OK**: Successful operation
+- **400 Bad Request**: Invalid request data
+- **500 Internal Server Error**: Server-side errors
+
+Error responses include descriptive messages:
+```json
+{
+  "error": "Test case not found with id: 123",
+  "timestamp": "2024-01-01T12:00:00Z"
+}
+```
+
+## QTest Integration Notes
+
+The system is designed to work with QTest test case links in Jira issues. It looks for patterns like:
+
+- "QTest: Test Case Name"
+- "Test Case: Test Case Name"
+- Bulleted lists with test case names
+- Numbered lists with test case names
+
+The extraction is flexible and can be customized by modifying the regex patterns in `JiraIntegrationService.java`.
+
+## Security Considerations
+
+1. **API Tokens**: Store Jira credentials securely
+2. **HTTPS**: Use HTTPS for all Jira API calls
+3. **Rate Limiting**: Be mindful of Jira API rate limits
+4. **Permissions**: Ensure proper Jira permissions for the integration user
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Connection Failed**: Check Jira URL, username, and token
+2. **No Sprints Found**: Verify board ID and project key
+3. **No Issues Found**: Check sprint ID and JQL permissions
+4. **Comments Not Accessible**: Verify comment read permissions
+
+### Logging
+
+Enable debug logging for detailed troubleshooting:
+```properties
+logging.level.com.qa.automation.service.JiraIntegrationService=DEBUG
+logging.level.com.qa.automation.service.ManualPageService=DEBUG
+```

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,24 @@
             <version>2.11.0</version>
         </dependency>
 
+        <!-- HTTP Client for Jira API -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- Apache HttpClient (alternative HTTP client) -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
+
+        <!-- Base64 encoding for authentication -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/qa/automation/config/JiraConfig.java
+++ b/src/main/java/com/qa/automation/config/JiraConfig.java
@@ -1,0 +1,90 @@
+package com.qa.automation.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import java.util.Base64;
+
+@Configuration
+public class JiraConfig {
+
+    @Value("${jira.url:}")
+    private String jiraUrl;
+
+    @Value("${jira.username:}")
+    private String jiraUsername;
+
+    @Value("${jira.token:}")
+    private String jiraToken;
+
+    @Value("${jira.project.key:}")
+    private String jiraProjectKey;
+
+    @Value("${jira.board.id:}")
+    private String jiraBoardId;
+
+    @Bean
+    public WebClient jiraWebClient() {
+        // Increase memory limit for large Jira responses
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        .maxInMemorySize(16 * 1024 * 1024)) // 16MB
+                .build();
+
+        return WebClient.builder()
+                .baseUrl(jiraUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, getBasicAuthHeader())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .defaultHeader(HttpHeaders.ACCEPT, "application/json")
+                .exchangeStrategies(strategies)
+                .build();
+    }
+
+    @Bean
+    public WebClient qtestWebClient() {
+        return WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .defaultHeader(HttpHeaders.ACCEPT, "application/json")
+                .build();
+    }
+
+    private String getBasicAuthHeader() {
+        if (jiraUsername == null || jiraToken == null || 
+            jiraUsername.isEmpty() || jiraToken.isEmpty()) {
+            return "";
+        }
+        String credentials = jiraUsername + ":" + jiraToken;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes());
+    }
+
+    // Getters for configuration values
+    public String getJiraUrl() {
+        return jiraUrl;
+    }
+
+    public String getJiraUsername() {
+        return jiraUsername;
+    }
+
+    public String getJiraToken() {
+        return jiraToken;
+    }
+
+    public String getJiraProjectKey() {
+        return jiraProjectKey;
+    }
+
+    public String getJiraBoardId() {
+        return jiraBoardId;
+    }
+
+    public boolean isConfigured() {
+        return jiraUrl != null && !jiraUrl.isEmpty() &&
+               jiraUsername != null && !jiraUsername.isEmpty() &&
+               jiraToken != null && !jiraToken.isEmpty();
+    }
+}

--- a/src/main/java/com/qa/automation/controller/ManualPageController.java
+++ b/src/main/java/com/qa/automation/controller/ManualPageController.java
@@ -1,0 +1,258 @@
+package com.qa.automation.controller;
+
+import com.qa.automation.dto.JiraIssueDto;
+import com.qa.automation.dto.JiraTestCaseDto;
+import com.qa.automation.model.Project;
+import com.qa.automation.model.Tester;
+import com.qa.automation.service.ManualPageService;
+import com.qa.automation.service.JiraIntegrationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/manual-page")
+@CrossOrigin(origins = {"http://localhost:4200", "http://localhost:5000"})
+public class ManualPageController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ManualPageController.class);
+
+    @Autowired
+    private ManualPageService manualPageService;
+
+    @Autowired
+    private JiraIntegrationService jiraIntegrationService;
+
+    /**
+     * Get all available sprints
+     */
+    @GetMapping("/sprints")
+    public ResponseEntity<List<Map<String, Object>>> getAvailableSprints() {
+        try {
+            logger.info("Fetching available sprints");
+            List<Map<String, Object>> sprints = manualPageService.getAvailableSprints();
+            return ResponseEntity.ok(sprints);
+        } catch (Exception e) {
+            logger.error("Error fetching sprints: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Fetch and sync issues from a specific sprint
+     */
+    @PostMapping("/sprints/{sprintId}/sync")
+    public ResponseEntity<List<JiraIssueDto>> syncSprintIssues(@PathVariable String sprintId) {
+        try {
+            logger.info("Syncing issues for sprint: {}", sprintId);
+            List<JiraIssueDto> issues = manualPageService.fetchAndSyncSprintIssues(sprintId);
+            return ResponseEntity.ok(issues);
+        } catch (Exception e) {
+            logger.error("Error syncing sprint issues: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Get saved issues for a specific sprint
+     */
+    @GetMapping("/sprints/{sprintId}/issues")
+    public ResponseEntity<List<JiraIssueDto>> getSprintIssues(@PathVariable String sprintId) {
+        try {
+            logger.info("Getting issues for sprint: {}", sprintId);
+            List<JiraIssueDto> issues = manualPageService.getSprintIssues(sprintId);
+            return ResponseEntity.ok(issues);
+        } catch (Exception e) {
+            logger.error("Error getting sprint issues: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Update test case automation flags
+     */
+    @PutMapping("/test-cases/{testCaseId}/automation-flags")
+    public ResponseEntity<JiraTestCaseDto> updateAutomationFlags(
+            @PathVariable Long testCaseId,
+            @RequestBody AutomationFlagsRequest request) {
+        try {
+            logger.info("Updating automation flags for test case: {}", testCaseId);
+            JiraTestCaseDto updatedTestCase = manualPageService.updateTestCaseAutomationFlags(
+                    testCaseId, 
+                    request.getCanBeAutomated(), 
+                    request.getCannotBeAutomated()
+            );
+            return ResponseEntity.ok(updatedTestCase);
+        } catch (Exception e) {
+            logger.error("Error updating automation flags: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    /**
+     * Map test case to project and assign tester
+     */
+    @PutMapping("/test-cases/{testCaseId}/mapping")
+    public ResponseEntity<JiraTestCaseDto> mapTestCase(
+            @PathVariable Long testCaseId,
+            @RequestBody TestCaseMappingRequest request) {
+        try {
+            logger.info("Mapping test case {} to project {} and tester {}", 
+                    testCaseId, request.getProjectId(), request.getTesterId());
+            JiraTestCaseDto updatedTestCase = manualPageService.mapTestCaseToProject(
+                    testCaseId, 
+                    request.getProjectId(), 
+                    request.getTesterId()
+            );
+            return ResponseEntity.ok(updatedTestCase);
+        } catch (Exception e) {
+            logger.error("Error mapping test case: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    /**
+     * Search for keyword in issue comments
+     */
+    @PostMapping("/issues/{jiraKey}/keyword-search")
+    public ResponseEntity<JiraIssueDto> searchKeywordInComments(
+            @PathVariable String jiraKey,
+            @RequestBody KeywordSearchRequest request) {
+        try {
+            logger.info("Searching for keyword '{}' in issue: {}", request.getKeyword(), jiraKey);
+            JiraIssueDto updatedIssue = manualPageService.searchKeywordInIssue(jiraKey, request.getKeyword());
+            return ResponseEntity.ok(updatedIssue);
+        } catch (Exception e) {
+            logger.error("Error searching keyword in comments: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    /**
+     * Get automation statistics for a sprint
+     */
+    @GetMapping("/sprints/{sprintId}/statistics")
+    public ResponseEntity<Map<String, Object>> getSprintStatistics(@PathVariable String sprintId) {
+        try {
+            logger.info("Getting automation statistics for sprint: {}", sprintId);
+            Map<String, Object> statistics = manualPageService.getSprintAutomationStatistics(sprintId);
+            return ResponseEntity.ok(statistics);
+        } catch (Exception e) {
+            logger.error("Error getting sprint statistics: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Get all projects for mapping
+     */
+    @GetMapping("/projects")
+    public ResponseEntity<List<Project>> getAllProjects() {
+        try {
+            logger.info("Getting all projects for mapping");
+            List<Project> projects = manualPageService.getAllProjects();
+            return ResponseEntity.ok(projects);
+        } catch (Exception e) {
+            logger.error("Error getting projects: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Get all testers for assignment
+     */
+    @GetMapping("/testers")
+    public ResponseEntity<List<Tester>> getAllTesters() {
+        try {
+            logger.info("Getting all testers for assignment");
+            List<Tester> testers = manualPageService.getAllTesters();
+            return ResponseEntity.ok(testers);
+        } catch (Exception e) {
+            logger.error("Error getting testers: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * Test Jira connection
+     */
+    @GetMapping("/test-connection")
+    public ResponseEntity<Map<String, Object>> testConnection() {
+        try {
+            logger.info("Testing Jira connection");
+            boolean isConnected = jiraIntegrationService.testConnection();
+            Map<String, Object> response = Map.of(
+                    "connected", isConnected,
+                    "message", isConnected ? "Successfully connected to Jira" : "Failed to connect to Jira"
+            );
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            logger.error("Error testing connection: {}", e.getMessage(), e);
+            Map<String, Object> response = Map.of(
+                    "connected", false,
+                    "message", "Error testing connection: " + e.getMessage()
+            );
+            return ResponseEntity.ok(response);
+        }
+    }
+
+    // Request DTOs
+    public static class AutomationFlagsRequest {
+        private boolean canBeAutomated;
+        private boolean cannotBeAutomated;
+
+        public boolean getCanBeAutomated() {
+            return canBeAutomated;
+        }
+
+        public void setCanBeAutomated(boolean canBeAutomated) {
+            this.canBeAutomated = canBeAutomated;
+        }
+
+        public boolean getCannotBeAutomated() {
+            return cannotBeAutomated;
+        }
+
+        public void setCannotBeAutomated(boolean cannotBeAutomated) {
+            this.cannotBeAutomated = cannotBeAutomated;
+        }
+    }
+
+    public static class TestCaseMappingRequest {
+        private Long projectId;
+        private Long testerId;
+
+        public Long getProjectId() {
+            return projectId;
+        }
+
+        public void setProjectId(Long projectId) {
+            this.projectId = projectId;
+        }
+
+        public Long getTesterId() {
+            return testerId;
+        }
+
+        public void setTesterId(Long testerId) {
+            this.testerId = testerId;
+        }
+    }
+
+    public static class KeywordSearchRequest {
+        private String keyword;
+
+        public String getKeyword() {
+            return keyword;
+        }
+
+        public void setKeyword(String keyword) {
+            this.keyword = keyword;
+        }
+    }
+}

--- a/src/main/java/com/qa/automation/dto/JiraIssueDto.java
+++ b/src/main/java/com/qa/automation/dto/JiraIssueDto.java
@@ -1,0 +1,187 @@
+package com.qa.automation.dto;
+
+import com.qa.automation.model.JiraTestCase;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.ArrayList;
+
+public class JiraIssueDto {
+    private Long id;
+    private String jiraKey;
+    private String summary;
+    private String description;
+    private String assignee;
+    private String assigneeDisplayName;
+    private String sprintId;
+    private String sprintName;
+    private String issueType;
+    private String status;
+    private String priority;
+    private Integer keywordCount;
+    private String searchKeyword;
+    private List<JiraTestCaseDto> linkedTestCases = new ArrayList<>();
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructors
+    public JiraIssueDto() {}
+
+    public JiraIssueDto(String jiraKey, String summary, String description, String assignee) {
+        this.jiraKey = jiraKey;
+        this.summary = summary;
+        this.description = description;
+        this.assignee = assignee;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getJiraKey() {
+        return jiraKey;
+    }
+
+    public void setJiraKey(String jiraKey) {
+        this.jiraKey = jiraKey;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getAssignee() {
+        return assignee;
+    }
+
+    public void setAssignee(String assignee) {
+        this.assignee = assignee;
+    }
+
+    public String getAssigneeDisplayName() {
+        return assigneeDisplayName;
+    }
+
+    public void setAssigneeDisplayName(String assigneeDisplayName) {
+        this.assigneeDisplayName = assigneeDisplayName;
+    }
+
+    public String getSprintId() {
+        return sprintId;
+    }
+
+    public void setSprintId(String sprintId) {
+        this.sprintId = sprintId;
+    }
+
+    public String getSprintName() {
+        return sprintName;
+    }
+
+    public void setSprintName(String sprintName) {
+        this.sprintName = sprintName;
+    }
+
+    public String getIssueType() {
+        return issueType;
+    }
+
+    public void setIssueType(String issueType) {
+        this.issueType = issueType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public Integer getKeywordCount() {
+        return keywordCount;
+    }
+
+    public void setKeywordCount(Integer keywordCount) {
+        this.keywordCount = keywordCount;
+    }
+
+    public String getSearchKeyword() {
+        return searchKeyword;
+    }
+
+    public void setSearchKeyword(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+
+    public List<JiraTestCaseDto> getLinkedTestCases() {
+        return linkedTestCases;
+    }
+
+    public void setLinkedTestCases(List<JiraTestCaseDto> linkedTestCases) {
+        this.linkedTestCases = linkedTestCases;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // Helper methods
+    public void addLinkedTestCase(JiraTestCaseDto testCase) {
+        this.linkedTestCases.add(testCase);
+    }
+
+    public int getAutomationReadyCount() {
+        return (int) linkedTestCases.stream()
+                .filter(tc -> "READY_TO_AUTOMATE".equals(tc.getAutomationStatus()))
+                .count();
+    }
+
+    public int getNotAutomatableCount() {
+        return (int) linkedTestCases.stream()
+                .filter(tc -> "NOT_AUTOMATABLE".equals(tc.getAutomationStatus()))
+                .count();
+    }
+
+    public int getPendingCount() {
+        return (int) linkedTestCases.stream()
+                .filter(tc -> "PENDING".equals(tc.getAutomationStatus()))
+                .count();
+    }
+}

--- a/src/main/java/com/qa/automation/dto/JiraTestCaseDto.java
+++ b/src/main/java/com/qa/automation/dto/JiraTestCaseDto.java
@@ -1,0 +1,170 @@
+package com.qa.automation.dto;
+
+import java.time.LocalDateTime;
+
+public class JiraTestCaseDto {
+    private Long id;
+    private String qtestTitle;
+    private String qtestId;
+    private Boolean canBeAutomated;
+    private Boolean cannotBeAutomated;
+    private String automationStatus;
+    private Long assignedTesterId;
+    private String assignedTesterName;
+    private Long projectId;
+    private String projectName;
+    private String domainMapped;
+    private String notes;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructors
+    public JiraTestCaseDto() {}
+
+    public JiraTestCaseDto(String qtestTitle) {
+        this.qtestTitle = qtestTitle;
+        this.canBeAutomated = false;
+        this.cannotBeAutomated = false;
+        this.automationStatus = "PENDING";
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getQtestTitle() {
+        return qtestTitle;
+    }
+
+    public void setQtestTitle(String qtestTitle) {
+        this.qtestTitle = qtestTitle;
+    }
+
+    public String getQtestId() {
+        return qtestId;
+    }
+
+    public void setQtestId(String qtestId) {
+        this.qtestId = qtestId;
+    }
+
+    public Boolean getCanBeAutomated() {
+        return canBeAutomated;
+    }
+
+    public void setCanBeAutomated(Boolean canBeAutomated) {
+        this.canBeAutomated = canBeAutomated;
+        updateAutomationStatus();
+    }
+
+    public Boolean getCannotBeAutomated() {
+        return cannotBeAutomated;
+    }
+
+    public void setCannotBeAutomated(Boolean cannotBeAutomated) {
+        this.cannotBeAutomated = cannotBeAutomated;
+        updateAutomationStatus();
+    }
+
+    public String getAutomationStatus() {
+        return automationStatus;
+    }
+
+    public void setAutomationStatus(String automationStatus) {
+        this.automationStatus = automationStatus;
+    }
+
+    public Long getAssignedTesterId() {
+        return assignedTesterId;
+    }
+
+    public void setAssignedTesterId(Long assignedTesterId) {
+        this.assignedTesterId = assignedTesterId;
+    }
+
+    public String getAssignedTesterName() {
+        return assignedTesterName;
+    }
+
+    public void setAssignedTesterName(String assignedTesterName) {
+        this.assignedTesterName = assignedTesterName;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    public String getDomainMapped() {
+        return domainMapped;
+    }
+
+    public void setDomainMapped(String domainMapped) {
+        this.domainMapped = domainMapped;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // Helper methods
+    private void updateAutomationStatus() {
+        if (canBeAutomated != null && cannotBeAutomated != null) {
+            if (canBeAutomated && !cannotBeAutomated) {
+                this.automationStatus = "READY_TO_AUTOMATE";
+            } else if (!canBeAutomated && cannotBeAutomated) {
+                this.automationStatus = "NOT_AUTOMATABLE";
+            } else {
+                this.automationStatus = "PENDING";
+            }
+        }
+    }
+
+    public boolean isReadyToAutomate() {
+        return "READY_TO_AUTOMATE".equals(automationStatus);
+    }
+
+    public boolean isNotAutomatable() {
+        return "NOT_AUTOMATABLE".equals(automationStatus);
+    }
+
+    public boolean isPending() {
+        return "PENDING".equals(automationStatus);
+    }
+}

--- a/src/main/java/com/qa/automation/model/JiraIssue.java
+++ b/src/main/java/com/qa/automation/model/JiraIssue.java
@@ -1,0 +1,235 @@
+package com.qa.automation.model;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.ArrayList;
+
+@Entity
+@Table(name = "jira_issues")
+public class JiraIssue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "jira_key", nullable = false, unique = true)
+    private String jiraKey;
+
+    @Column(nullable = false)
+    private String summary;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "assignee")
+    private String assignee;
+
+    @Column(name = "assignee_display_name")
+    private String assigneeDisplayName;
+
+    @Column(name = "sprint_id")
+    private String sprintId;
+
+    @Column(name = "sprint_name")
+    private String sprintName;
+
+    @Column(name = "issue_type")
+    private String issueType;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "priority")
+    private String priority;
+
+    @Column(name = "keyword_count")
+    private Integer keywordCount = 0;
+
+    @Column(name = "search_keyword")
+    private String searchKeyword;
+
+    @OneToMany(mappedBy = "jiraIssue", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnoreProperties("jiraIssue")
+    private List<JiraTestCase> linkedTestCases = new ArrayList<>();
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // Constructors
+    public JiraIssue() {}
+
+    public JiraIssue(String jiraKey, String summary, String description, String assignee) {
+        this.jiraKey = jiraKey;
+        this.summary = summary;
+        this.description = description;
+        this.assignee = assignee;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getJiraKey() {
+        return jiraKey;
+    }
+
+    public void setJiraKey(String jiraKey) {
+        this.jiraKey = jiraKey;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getAssignee() {
+        return assignee;
+    }
+
+    public void setAssignee(String assignee) {
+        this.assignee = assignee;
+    }
+
+    public String getAssigneeDisplayName() {
+        return assigneeDisplayName;
+    }
+
+    public void setAssigneeDisplayName(String assigneeDisplayName) {
+        this.assigneeDisplayName = assigneeDisplayName;
+    }
+
+    public String getSprintId() {
+        return sprintId;
+    }
+
+    public void setSprintId(String sprintId) {
+        this.sprintId = sprintId;
+    }
+
+    public String getSprintName() {
+        return sprintName;
+    }
+
+    public void setSprintName(String sprintName) {
+        this.sprintName = sprintName;
+    }
+
+    public String getIssueType() {
+        return issueType;
+    }
+
+    public void setIssueType(String issueType) {
+        this.issueType = issueType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public Integer getKeywordCount() {
+        return keywordCount;
+    }
+
+    public void setKeywordCount(Integer keywordCount) {
+        this.keywordCount = keywordCount;
+    }
+
+    public String getSearchKeyword() {
+        return searchKeyword;
+    }
+
+    public void setSearchKeyword(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+
+    public List<JiraTestCase> getLinkedTestCases() {
+        return linkedTestCases;
+    }
+
+    public void setLinkedTestCases(List<JiraTestCase> linkedTestCases) {
+        this.linkedTestCases = linkedTestCases;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // Helper methods
+    public void addLinkedTestCase(JiraTestCase testCase) {
+        linkedTestCases.add(testCase);
+        testCase.setJiraIssue(this);
+    }
+
+    public void removeLinkedTestCase(JiraTestCase testCase) {
+        linkedTestCases.remove(testCase);
+        testCase.setJiraIssue(null);
+    }
+
+    @Override
+    public String toString() {
+        return "JiraIssue{" +
+                "id=" + id +
+                ", jiraKey='" + jiraKey + '\'' +
+                ", summary='" + summary + '\'' +
+                ", assignee='" + assignee + '\'' +
+                ", sprintName='" + sprintName + '\'' +
+                ", keywordCount=" + keywordCount +
+                '}';
+    }
+}

--- a/src/main/java/com/qa/automation/model/JiraTestCase.java
+++ b/src/main/java/com/qa/automation/model/JiraTestCase.java
@@ -1,0 +1,238 @@
+package com.qa.automation.model;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "jira_test_cases")
+public class JiraTestCase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "qtest_title", nullable = false)
+    private String qtestTitle;
+
+    @Column(name = "qtest_id")
+    private String qtestId;
+
+    @Column(name = "can_be_automated", nullable = false)
+    private Boolean canBeAutomated = false;
+
+    @Column(name = "cannot_be_automated", nullable = false)
+    private Boolean cannotBeAutomated = false;
+
+    @Column(name = "automation_status")
+    private String automationStatus; // "READY_TO_AUTOMATE", "NOT_AUTOMATABLE", "PENDING"
+
+    @Column(name = "assigned_tester_id")
+    private Long assignedTesterId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "jira_issue_id", nullable = false)
+    @JsonIgnoreProperties("linkedTestCases")
+    private JiraIssue jiraIssue;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "project_id")
+    @JsonIgnoreProperties({"testCases", "domain"})
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "tester_id")
+    @JsonIgnoreProperties("testCases")
+    private Tester assignedTester;
+
+    @Column(name = "domain_mapped")
+    private String domainMapped;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        
+        // Set automation status based on checkbox values
+        updateAutomationStatus();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+        
+        // Update automation status based on checkbox values
+        updateAutomationStatus();
+    }
+
+    // Constructors
+    public JiraTestCase() {}
+
+    public JiraTestCase(String qtestTitle, JiraIssue jiraIssue) {
+        this.qtestTitle = qtestTitle;
+        this.jiraIssue = jiraIssue;
+    }
+
+    // Private method to update automation status
+    private void updateAutomationStatus() {
+        if (canBeAutomated && !cannotBeAutomated) {
+            this.automationStatus = "READY_TO_AUTOMATE";
+        } else if (!canBeAutomated && cannotBeAutomated) {
+            this.automationStatus = "NOT_AUTOMATABLE";
+        } else {
+            this.automationStatus = "PENDING";
+        }
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getQtestTitle() {
+        return qtestTitle;
+    }
+
+    public void setQtestTitle(String qtestTitle) {
+        this.qtestTitle = qtestTitle;
+    }
+
+    public String getQtestId() {
+        return qtestId;
+    }
+
+    public void setQtestId(String qtestId) {
+        this.qtestId = qtestId;
+    }
+
+    public Boolean getCanBeAutomated() {
+        return canBeAutomated;
+    }
+
+    public void setCanBeAutomated(Boolean canBeAutomated) {
+        this.canBeAutomated = canBeAutomated;
+        updateAutomationStatus();
+    }
+
+    public Boolean getCannotBeAutomated() {
+        return cannotBeAutomated;
+    }
+
+    public void setCannotBeAutomated(Boolean cannotBeAutomated) {
+        this.cannotBeAutomated = cannotBeAutomated;
+        updateAutomationStatus();
+    }
+
+    public String getAutomationStatus() {
+        return automationStatus;
+    }
+
+    public void setAutomationStatus(String automationStatus) {
+        this.automationStatus = automationStatus;
+    }
+
+    public Long getAssignedTesterId() {
+        return assignedTesterId;
+    }
+
+    public void setAssignedTesterId(Long assignedTesterId) {
+        this.assignedTesterId = assignedTesterId;
+    }
+
+    public JiraIssue getJiraIssue() {
+        return jiraIssue;
+    }
+
+    public void setJiraIssue(JiraIssue jiraIssue) {
+        this.jiraIssue = jiraIssue;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
+    public Tester getAssignedTester() {
+        return assignedTester;
+    }
+
+    public void setAssignedTester(Tester assignedTester) {
+        this.assignedTester = assignedTester;
+        if (assignedTester != null) {
+            this.assignedTesterId = assignedTester.getId();
+        }
+    }
+
+    public String getDomainMapped() {
+        return domainMapped;
+    }
+
+    public void setDomainMapped(String domainMapped) {
+        this.domainMapped = domainMapped;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // Helper methods
+    public boolean isReadyToAutomate() {
+        return "READY_TO_AUTOMATE".equals(automationStatus);
+    }
+
+    public boolean isNotAutomatable() {
+        return "NOT_AUTOMATABLE".equals(automationStatus);
+    }
+
+    public boolean isPending() {
+        return "PENDING".equals(automationStatus);
+    }
+
+    @Override
+    public String toString() {
+        return "JiraTestCase{" +
+                "id=" + id +
+                ", qtestTitle='" + qtestTitle + '\'' +
+                ", canBeAutomated=" + canBeAutomated +
+                ", cannotBeAutomated=" + cannotBeAutomated +
+                ", automationStatus='" + automationStatus + '\'' +
+                ", jiraIssue=" + (jiraIssue != null ? jiraIssue.getJiraKey() : null) +
+                '}';
+    }
+}

--- a/src/main/java/com/qa/automation/repository/JiraIssueRepository.java
+++ b/src/main/java/com/qa/automation/repository/JiraIssueRepository.java
@@ -1,0 +1,67 @@
+package com.qa.automation.repository;
+
+import com.qa.automation.model.JiraIssue;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface JiraIssueRepository extends JpaRepository<JiraIssue, Long> {
+
+    // Find by Jira key (unique identifier)
+    Optional<JiraIssue> findByJiraKey(String jiraKey);
+
+    // Find all issues for a specific sprint
+    List<JiraIssue> findBySprintId(String sprintId);
+
+    // Find by sprint name
+    List<JiraIssue> findBySprintName(String sprintName);
+
+    // Find by assignee
+    List<JiraIssue> findByAssignee(String assignee);
+
+    // Find by issue type
+    List<JiraIssue> findByIssueType(String issueType);
+
+    // Find by status
+    List<JiraIssue> findByStatus(String status);
+
+    // Find issues with keyword count greater than zero
+    @Query("SELECT ji FROM JiraIssue ji WHERE ji.keywordCount > 0")
+    List<JiraIssue> findIssuesWithKeywords();
+
+    // Find by sprint and keyword search
+    @Query("SELECT ji FROM JiraIssue ji WHERE ji.sprintId = :sprintId AND ji.searchKeyword = :keyword")
+    List<JiraIssue> findBySprintIdAndKeyword(@Param("sprintId") String sprintId, @Param("keyword") String keyword);
+
+    // Find issues with linked test cases
+    @Query("SELECT DISTINCT ji FROM JiraIssue ji LEFT JOIN FETCH ji.linkedTestCases")
+    List<JiraIssue> findAllWithLinkedTestCases();
+
+    // Find issues by sprint with linked test cases
+    @Query("SELECT DISTINCT ji FROM JiraIssue ji LEFT JOIN FETCH ji.linkedTestCases WHERE ji.sprintId = :sprintId")
+    List<JiraIssue> findBySprintIdWithLinkedTestCases(@Param("sprintId") String sprintId);
+
+    // Find issues by assignee with linked test cases
+    @Query("SELECT DISTINCT ji FROM JiraIssue ji LEFT JOIN FETCH ji.linkedTestCases WHERE ji.assignee = :assignee")
+    List<JiraIssue> findByAssigneeWithLinkedTestCases(@Param("assignee") String assignee);
+
+    // Check if issue exists by Jira key
+    boolean existsByJiraKey(String jiraKey);
+
+    // Count by sprint
+    @Query("SELECT COUNT(ji) FROM JiraIssue ji WHERE ji.sprintId = :sprintId")
+    Long countBySprintId(@Param("sprintId") String sprintId);
+
+    // Get all sprint names
+    @Query("SELECT DISTINCT ji.sprintName FROM JiraIssue ji WHERE ji.sprintName IS NOT NULL ORDER BY ji.sprintName")
+    List<String> findDistinctSprintNames();
+
+    // Get all assignees
+    @Query("SELECT DISTINCT ji.assignee FROM JiraIssue ji WHERE ji.assignee IS NOT NULL ORDER BY ji.assignee")
+    List<String> findDistinctAssignees();
+}

--- a/src/main/java/com/qa/automation/repository/JiraTestCaseRepository.java
+++ b/src/main/java/com/qa/automation/repository/JiraTestCaseRepository.java
@@ -1,0 +1,99 @@
+package com.qa.automation.repository;
+
+import com.qa.automation.model.JiraTestCase;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface JiraTestCaseRepository extends JpaRepository<JiraTestCase, Long> {
+
+    // Find by QTest title
+    List<JiraTestCase> findByQtestTitle(String qtestTitle);
+
+    // Find by QTest ID
+    Optional<JiraTestCase> findByQtestId(String qtestId);
+
+    // Find by Jira issue ID
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.jiraIssue.id = :jiraIssueId")
+    List<JiraTestCase> findByJiraIssueId(@Param("jiraIssueId") Long jiraIssueId);
+
+    // Find by Jira issue key
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.jiraIssue.jiraKey = :jiraKey")
+    List<JiraTestCase> findByJiraIssueKey(@Param("jiraKey") String jiraKey);
+
+    // Find by automation status
+    List<JiraTestCase> findByAutomationStatus(String automationStatus);
+
+    // Find ready to automate test cases
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.automationStatus = 'READY_TO_AUTOMATE'")
+    List<JiraTestCase> findReadyToAutomate();
+
+    // Find not automatable test cases
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.automationStatus = 'NOT_AUTOMATABLE'")
+    List<JiraTestCase> findNotAutomatable();
+
+    // Find pending test cases
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.automationStatus = 'PENDING'")
+    List<JiraTestCase> findPending();
+
+    // Find by project ID
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.project.id = :projectId")
+    List<JiraTestCase> findByProjectId(@Param("projectId") Long projectId);
+
+    // Find by assigned tester ID
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.assignedTester.id = :testerId")
+    List<JiraTestCase> findByAssignedTesterId(@Param("testerId") Long testerId);
+
+    // Find test cases with project mapping
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.project IS NOT NULL")
+    List<JiraTestCase> findWithProjectMapping();
+
+    // Find test cases without project mapping
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.project IS NULL")
+    List<JiraTestCase> findWithoutProjectMapping();
+
+    // Count by automation status
+    @Query("SELECT COUNT(jtc) FROM JiraTestCase jtc WHERE jtc.automationStatus = :status")
+    Long countByAutomationStatus(@Param("status") String status);
+
+    // Count ready to automate by project
+    @Query("SELECT COUNT(jtc) FROM JiraTestCase jtc WHERE jtc.automationStatus = 'READY_TO_AUTOMATE' AND jtc.project.id = :projectId")
+    Long countReadyToAutomateByProject(@Param("projectId") Long projectId);
+
+    // Find by sprint ID through Jira issue
+    @Query("SELECT jtc FROM JiraTestCase jtc WHERE jtc.jiraIssue.sprintId = :sprintId")
+    List<JiraTestCase> findBySprintId(@Param("sprintId") String sprintId);
+
+    // Find by domain mapped
+    List<JiraTestCase> findByDomainMapped(String domainMapped);
+
+    // Check if test case exists by QTest title and Jira issue
+    @Query("SELECT COUNT(jtc) > 0 FROM JiraTestCase jtc WHERE jtc.qtestTitle = :qtestTitle AND jtc.jiraIssue.id = :jiraIssueId")
+    boolean existsByQtestTitleAndJiraIssueId(@Param("qtestTitle") String qtestTitle, @Param("jiraIssueId") Long jiraIssueId);
+
+    // Get automation statistics
+    @Query("SELECT " +
+           "SUM(CASE WHEN jtc.automationStatus = 'READY_TO_AUTOMATE' THEN 1 ELSE 0 END) as readyCount, " +
+           "SUM(CASE WHEN jtc.automationStatus = 'NOT_AUTOMATABLE' THEN 1 ELSE 0 END) as notAutomatableCount, " +
+           "SUM(CASE WHEN jtc.automationStatus = 'PENDING' THEN 1 ELSE 0 END) as pendingCount, " +
+           "COUNT(jtc) as totalCount " +
+           "FROM JiraTestCase jtc")
+    Object[] getAutomationStatistics();
+
+    // Get automation statistics by project
+    @Query("SELECT " +
+           "p.name as projectName, " +
+           "SUM(CASE WHEN jtc.automationStatus = 'READY_TO_AUTOMATE' THEN 1 ELSE 0 END) as readyCount, " +
+           "SUM(CASE WHEN jtc.automationStatus = 'NOT_AUTOMATABLE' THEN 1 ELSE 0 END) as notAutomatableCount, " +
+           "SUM(CASE WHEN jtc.automationStatus = 'PENDING' THEN 1 ELSE 0 END) as pendingCount, " +
+           "COUNT(jtc) as totalCount " +
+           "FROM JiraTestCase jtc " +
+           "LEFT JOIN jtc.project p " +
+           "GROUP BY p.name")
+    List<Object[]> getAutomationStatisticsByProject();
+}

--- a/src/main/java/com/qa/automation/service/JiraIntegrationService.java
+++ b/src/main/java/com/qa/automation/service/JiraIntegrationService.java
@@ -1,0 +1,418 @@
+package com.qa.automation.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qa.automation.config.JiraConfig;
+import com.qa.automation.dto.JiraIssueDto;
+import com.qa.automation.dto.JiraTestCaseDto;
+import com.qa.automation.model.JiraIssue;
+import com.qa.automation.model.JiraTestCase;
+import com.qa.automation.repository.JiraIssueRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+public class JiraIntegrationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(JiraIntegrationService.class);
+
+    @Autowired
+    private JiraConfig jiraConfig;
+
+    @Autowired
+    private WebClient jiraWebClient;
+
+    @Autowired
+    private JiraIssueRepository jiraIssueRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // Pattern to extract QTest test case links from Jira issues
+    private static final Pattern QTEST_PATTERN = Pattern.compile(
+            "(?i)(?:qtest|test\\s*case)\\s*:?\\s*([\\w\\s\\-_.,()\\[\\]]+)", 
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /**
+     * Fetch all issues from a specific sprint
+     */
+    public List<JiraIssueDto> fetchIssuesFromSprint(String sprintId) {
+        if (!jiraConfig.isConfigured()) {
+            logger.warn("Jira configuration is not complete");
+            return new ArrayList<>();
+        }
+
+        try {
+            String jql = String.format("sprint = %s AND project = %s", sprintId, jiraConfig.getJiraProjectKey());
+            String url = String.format("/rest/api/2/search?jql=%s&maxResults=1000&expand=changelog", 
+                    jql.replace(" ", "%20"));
+
+            logger.info("Fetching Jira issues from sprint: {} using JQL: {}", sprintId, jql);
+
+            String response = jiraWebClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(30))
+                    .block();
+
+            return parseJiraResponse(response, sprintId);
+
+        } catch (WebClientResponseException e) {
+            logger.error("Error fetching Jira issues from sprint {}: {} - {}", 
+                    sprintId, e.getStatusCode(), e.getResponseBodyAsString());
+            return new ArrayList<>();
+        } catch (Exception e) {
+            logger.error("Unexpected error fetching Jira issues from sprint {}: {}", sprintId, e.getMessage(), e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Fetch all sprints for the configured board
+     */
+    public List<Map<String, Object>> fetchSprints() {
+        if (!jiraConfig.isConfigured()) {
+            logger.warn("Jira configuration is not complete");
+            return new ArrayList<>();
+        }
+
+        try {
+            String url = String.format("/rest/agile/1.0/board/%s/sprint", jiraConfig.getJiraBoardId());
+            
+            logger.info("Fetching sprints for board: {}", jiraConfig.getJiraBoardId());
+
+            String response = jiraWebClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(30))
+                    .block();
+
+            return parseSprintsResponse(response);
+
+        } catch (WebClientResponseException e) {
+            logger.error("Error fetching sprints: {} - {}", e.getStatusCode(), e.getResponseBodyAsString());
+            return new ArrayList<>();
+        } catch (Exception e) {
+            logger.error("Unexpected error fetching sprints: {}", e.getMessage(), e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Search for a keyword in issue comments and return count
+     */
+    public int searchKeywordInComments(String issueKey, String keyword) {
+        if (!jiraConfig.isConfigured() || issueKey == null || keyword == null) {
+            return 0;
+        }
+
+        try {
+            String url = String.format("/rest/api/2/issue/%s/comment", issueKey);
+            
+            logger.debug("Searching for keyword '{}' in comments of issue: {}", keyword, issueKey);
+
+            String response = jiraWebClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(15))
+                    .block();
+
+            return countKeywordInComments(response, keyword);
+
+        } catch (WebClientResponseException e) {
+            logger.warn("Error fetching comments for issue {}: {} - {}", 
+                    issueKey, e.getStatusCode(), e.getResponseBodyAsString());
+            return 0;
+        } catch (Exception e) {
+            logger.warn("Unexpected error fetching comments for issue {}: {}", issueKey, e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * Parse Jira API response and convert to DTOs
+     */
+    private List<JiraIssueDto> parseJiraResponse(String response, String sprintId) {
+        List<JiraIssueDto> issues = new ArrayList<>();
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode issuesNode = rootNode.path("issues");
+
+            for (JsonNode issueNode : issuesNode) {
+                JiraIssueDto issueDto = parseIssueNode(issueNode, sprintId);
+                if (issueDto != null) {
+                    issues.add(issueDto);
+                }
+            }
+
+            logger.info("Parsed {} issues from Jira response", issues.size());
+
+        } catch (Exception e) {
+            logger.error("Error parsing Jira response: {}", e.getMessage(), e);
+        }
+
+        return issues;
+    }
+
+    /**
+     * Parse individual issue node from Jira response
+     */
+    private JiraIssueDto parseIssueNode(JsonNode issueNode, String sprintId) {
+        try {
+            String key = issueNode.path("key").asText();
+            JsonNode fields = issueNode.path("fields");
+
+            JiraIssueDto issueDto = new JiraIssueDto();
+            issueDto.setJiraKey(key);
+            issueDto.setSummary(fields.path("summary").asText());
+            issueDto.setDescription(getTextValue(fields.path("description")));
+            issueDto.setSprintId(sprintId);
+            issueDto.setIssueType(fields.path("issuetype").path("name").asText());
+            issueDto.setStatus(fields.path("status").path("name").asText());
+            
+            // Get priority safely
+            JsonNode priorityNode = fields.path("priority");
+            if (!priorityNode.isMissingNode() && !priorityNode.isNull()) {
+                issueDto.setPriority(priorityNode.path("name").asText());
+            }
+
+            // Get assignee information
+            JsonNode assigneeNode = fields.path("assignee");
+            if (!assigneeNode.isMissingNode() && !assigneeNode.isNull()) {
+                issueDto.setAssignee(assigneeNode.path("name").asText());
+                issueDto.setAssigneeDisplayName(assigneeNode.path("displayName").asText());
+            }
+
+            // Get sprint name from sprint field
+            JsonNode sprintNode = fields.path("customfield_10020"); // This is typically the sprint field
+            if (!sprintNode.isMissingNode() && sprintNode.isArray() && sprintNode.size() > 0) {
+                String sprintName = extractSprintName(sprintNode.get(0).asText());
+                issueDto.setSprintName(sprintName);
+            }
+
+            // Extract linked test cases from description and comments
+            List<JiraTestCaseDto> linkedTestCases = extractLinkedTestCases(issueDto.getDescription());
+            issueDto.setLinkedTestCases(linkedTestCases);
+
+            return issueDto;
+
+        } catch (Exception e) {
+            logger.error("Error parsing issue node: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Extract sprint name from sprint string
+     */
+    private String extractSprintName(String sprintString) {
+        try {
+            // Sprint string format: "com.atlassian.greenhopper.service.sprint.Sprint@[id=123,name=Sprint 1,...]"
+            Pattern namePattern = Pattern.compile("name=([^,\\]]+)");
+            Matcher matcher = namePattern.matcher(sprintString);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+        } catch (Exception e) {
+            logger.debug("Could not extract sprint name from: {}", sprintString);
+        }
+        return "Sprint " + jiraConfig.getJiraBoardId(); // Fallback
+    }
+
+    /**
+     * Extract linked test cases from text using patterns
+     */
+    private List<JiraTestCaseDto> extractLinkedTestCases(String text) {
+        List<JiraTestCaseDto> testCases = new ArrayList<>();
+        
+        if (text == null || text.trim().isEmpty()) {
+            return testCases;
+        }
+
+        try {
+            // Look for QTest test case patterns
+            Matcher matcher = QTEST_PATTERN.matcher(text);
+            Set<String> foundTestCases = new HashSet<>(); // Avoid duplicates
+
+            while (matcher.find()) {
+                String testCaseTitle = matcher.group(1).trim();
+                if (!testCaseTitle.isEmpty() && !foundTestCases.contains(testCaseTitle)) {
+                    foundTestCases.add(testCaseTitle);
+                    JiraTestCaseDto testCaseDto = new JiraTestCaseDto(testCaseTitle);
+                    testCases.add(testCaseDto);
+                }
+            }
+
+            // Also look for bulleted or numbered lists that might be test cases
+            String[] lines = text.split("\n");
+            for (String line : lines) {
+                line = line.trim();
+                if (line.matches("^[*\\-•]\\s+.+") || line.matches("^\\d+\\.\\s+.+")) {
+                    String testCaseTitle = line.replaceFirst("^[*\\-•\\d\\.\\s]+", "").trim();
+                    if (testCaseTitle.length() > 10 && testCaseTitle.length() < 200 && 
+                        !foundTestCases.contains(testCaseTitle)) {
+                        foundTestCases.add(testCaseTitle);
+                        JiraTestCaseDto testCaseDto = new JiraTestCaseDto(testCaseTitle);
+                        testCases.add(testCaseDto);
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            logger.error("Error extracting test cases from text: {}", e.getMessage(), e);
+        }
+
+        logger.debug("Extracted {} test cases from issue text", testCases.size());
+        return testCases;
+    }
+
+    /**
+     * Parse sprints response from Jira Agile API
+     */
+    private List<Map<String, Object>> parseSprintsResponse(String response) {
+        List<Map<String, Object>> sprints = new ArrayList<>();
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode valuesNode = rootNode.path("values");
+
+            for (JsonNode sprintNode : valuesNode) {
+                Map<String, Object> sprint = new HashMap<>();
+                sprint.put("id", sprintNode.path("id").asText());
+                sprint.put("name", sprintNode.path("name").asText());
+                sprint.put("state", sprintNode.path("state").asText());
+                sprint.put("startDate", sprintNode.path("startDate").asText());
+                sprint.put("endDate", sprintNode.path("endDate").asText());
+                
+                sprints.add(sprint);
+            }
+
+            logger.info("Parsed {} sprints from Jira response", sprints.size());
+
+        } catch (Exception e) {
+            logger.error("Error parsing sprints response: {}", e.getMessage(), e);
+        }
+
+        return sprints;
+    }
+
+    /**
+     * Count keyword occurrences in comments
+     */
+    private int countKeywordInComments(String response, String keyword) {
+        int count = 0;
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode commentsNode = rootNode.path("comments");
+
+            String lowerKeyword = keyword.toLowerCase();
+
+            for (JsonNode commentNode : commentsNode) {
+                String commentBody = getTextValue(commentNode.path("body"));
+                if (commentBody != null) {
+                    String lowerComment = commentBody.toLowerCase();
+                    int index = 0;
+                    while ((index = lowerComment.indexOf(lowerKeyword, index)) != -1) {
+                        count++;
+                        index += lowerKeyword.length();
+                    }
+                }
+            }
+
+            logger.debug("Found {} occurrences of keyword '{}' in comments", count, keyword);
+
+        } catch (Exception e) {
+            logger.error("Error counting keyword in comments: {}", e.getMessage(), e);
+        }
+
+        return count;
+    }
+
+    /**
+     * Safely extract text value from JSON node (handles both string and object formats)
+     */
+    private String getTextValue(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return "";
+        }
+        
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        
+        // Handle Atlassian Document Format (ADF)
+        if (node.isObject()) {
+            try {
+                return extractTextFromADF(node);
+            } catch (Exception e) {
+                logger.debug("Could not extract text from ADF format: {}", e.getMessage());
+                return node.toString();
+            }
+        }
+        
+        return node.asText();
+    }
+
+    /**
+     * Extract plain text from Atlassian Document Format (ADF)
+     */
+    private String extractTextFromADF(JsonNode adfNode) {
+        StringBuilder text = new StringBuilder();
+        extractTextRecursive(adfNode, text);
+        return text.toString().trim();
+    }
+
+    private void extractTextRecursive(JsonNode node, StringBuilder text) {
+        if (node.has("text")) {
+            text.append(node.path("text").asText()).append(" ");
+        }
+        
+        if (node.has("content") && node.path("content").isArray()) {
+            for (JsonNode child : node.path("content")) {
+                extractTextRecursive(child, text);
+            }
+        }
+    }
+
+    /**
+     * Test connection to Jira
+     */
+    public boolean testConnection() {
+        if (!jiraConfig.isConfigured()) {
+            return false;
+        }
+
+        try {
+            String response = jiraWebClient.get()
+                    .uri("/rest/api/2/myself")
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(10))
+                    .block();
+
+            logger.info("Jira connection test successful");
+            return true;
+
+        } catch (Exception e) {
+            logger.error("Jira connection test failed: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/qa/automation/service/ManualPageService.java
+++ b/src/main/java/com/qa/automation/service/ManualPageService.java
@@ -1,0 +1,406 @@
+package com.qa.automation.service;
+
+import com.qa.automation.dto.JiraIssueDto;
+import com.qa.automation.dto.JiraTestCaseDto;
+import com.qa.automation.model.*;
+import com.qa.automation.repository.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class ManualPageService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ManualPageService.class);
+
+    @Autowired
+    private JiraIntegrationService jiraIntegrationService;
+
+    @Autowired
+    private TestCaseService testCaseService;
+
+    @Autowired
+    private JiraIssueRepository jiraIssueRepository;
+
+    @Autowired
+    private JiraTestCaseRepository jiraTestCaseRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TesterRepository testerRepository;
+
+    /**
+     * Fetch and sync issues from a specific sprint
+     */
+    public List<JiraIssueDto> fetchAndSyncSprintIssues(String sprintId) {
+        logger.info("Fetching and syncing issues from sprint: {}", sprintId);
+
+        // Fetch issues from Jira
+        List<JiraIssueDto> jiraIssues = jiraIntegrationService.fetchIssuesFromSprint(sprintId);
+
+        // Sync with database
+        List<JiraIssueDto> syncedIssues = new ArrayList<>();
+        for (JiraIssueDto issueDto : jiraIssues) {
+            try {
+                JiraIssueDto syncedIssue = syncIssueWithDatabase(issueDto);
+                syncedIssues.add(syncedIssue);
+            } catch (Exception e) {
+                logger.error("Error syncing issue {}: {}", issueDto.getJiraKey(), e.getMessage(), e);
+            }
+        }
+
+        logger.info("Synced {} issues for sprint {}", syncedIssues.size(), sprintId);
+        return syncedIssues;
+    }
+
+    /**
+     * Get all saved issues for a sprint
+     */
+    public List<JiraIssueDto> getSprintIssues(String sprintId) {
+        List<JiraIssue> issues = jiraIssueRepository.findBySprintIdWithLinkedTestCases(sprintId);
+        return issues.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Update test case automation flags
+     */
+    public JiraTestCaseDto updateTestCaseAutomationFlags(Long testCaseId, boolean canBeAutomated, boolean cannotBeAutomated) {
+        logger.info("Updating automation flags for test case {}: canAutomate={}, cannotAutomate={}", 
+                testCaseId, canBeAutomated, cannotBeAutomated);
+
+        Optional<JiraTestCase> optionalTestCase = jiraTestCaseRepository.findById(testCaseId);
+        if (optionalTestCase.isEmpty()) {
+            throw new RuntimeException("Test case not found with id: " + testCaseId);
+        }
+
+        JiraTestCase testCase = optionalTestCase.get();
+        testCase.setCanBeAutomated(canBeAutomated);
+        testCase.setCannotBeAutomated(cannotBeAutomated);
+
+        // If marked as "Can be Automated", trigger the automation readiness flow
+        if (canBeAutomated && !cannotBeAutomated) {
+            processAutomationReadiness(testCase);
+        }
+
+        JiraTestCase savedTestCase = jiraTestCaseRepository.save(testCase);
+        return convertTestCaseToDto(savedTestCase);
+    }
+
+    /**
+     * Search for keyword in issue comments and update count
+     */
+    public JiraIssueDto searchKeywordInIssue(String jiraKey, String keyword) {
+        logger.info("Searching for keyword '{}' in issue: {}", keyword, jiraKey);
+
+        Optional<JiraIssue> optionalIssue = jiraIssueRepository.findByJiraKey(jiraKey);
+        if (optionalIssue.isEmpty()) {
+            throw new RuntimeException("Issue not found with key: " + jiraKey);
+        }
+
+        JiraIssue issue = optionalIssue.get();
+        
+        // Search for keyword in comments via Jira API
+        int keywordCount = jiraIntegrationService.searchKeywordInComments(jiraKey, keyword);
+        
+        // Update the issue
+        issue.setKeywordCount(keywordCount);
+        issue.setSearchKeyword(keyword);
+        
+        JiraIssue savedIssue = jiraIssueRepository.save(issue);
+        return convertToDto(savedIssue);
+    }
+
+    /**
+     * Get automation statistics for a sprint
+     */
+    public Map<String, Object> getSprintAutomationStatistics(String sprintId) {
+        List<JiraTestCase> testCases = jiraTestCaseRepository.findBySprintId(sprintId);
+        
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("totalTestCases", testCases.size());
+        stats.put("readyToAutomate", testCases.stream().filter(tc -> tc.isReadyToAutomate()).count());
+        stats.put("notAutomatable", testCases.stream().filter(tc -> tc.isNotAutomatable()).count());
+        stats.put("pending", testCases.stream().filter(tc -> tc.isPending()).count());
+        
+        // Group by project
+        Map<String, Map<String, Long>> projectStats = testCases.stream()
+                .filter(tc -> tc.getProject() != null)
+                .collect(Collectors.groupingBy(
+                        tc -> tc.getProject().getName(),
+                        Collectors.groupingBy(
+                                JiraTestCase::getAutomationStatus,
+                                Collectors.counting()
+                        )
+                ));
+        
+        stats.put("projectBreakdown", projectStats);
+        
+        return stats;
+    }
+
+    /**
+     * Get all available sprints
+     */
+    public List<Map<String, Object>> getAvailableSprints() {
+        return jiraIntegrationService.fetchSprints();
+    }
+
+    /**
+     * Get all projects for mapping
+     */
+    public List<Project> getAllProjects() {
+        return projectRepository.findAll();
+    }
+
+    /**
+     * Get all testers for assignment
+     */
+    public List<Tester> getAllTesters() {
+        return testerRepository.findAll();
+    }
+
+    /**
+     * Map test case to project and domain
+     */
+    public JiraTestCaseDto mapTestCaseToProject(Long testCaseId, Long projectId, Long testerId) {
+        logger.info("Mapping test case {} to project {} and tester {}", testCaseId, projectId, testerId);
+
+        Optional<JiraTestCase> optionalTestCase = jiraTestCaseRepository.findById(testCaseId);
+        if (optionalTestCase.isEmpty()) {
+            throw new RuntimeException("Test case not found with id: " + testCaseId);
+        }
+
+        JiraTestCase testCase = optionalTestCase.get();
+
+        // Set project
+        if (projectId != null) {
+            Optional<Project> optionalProject = projectRepository.findById(projectId);
+            if (optionalProject.isPresent()) {
+                testCase.setProject(optionalProject.get());
+                if (optionalProject.get().getDomain() != null) {
+                    testCase.setDomainMapped(optionalProject.get().getDomain().getName());
+                }
+            }
+        }
+
+        // Set tester
+        if (testerId != null) {
+            Optional<Tester> optionalTester = testerRepository.findById(testerId);
+            if (optionalTester.isPresent()) {
+                testCase.setAssignedTester(optionalTester.get());
+            }
+        }
+
+        JiraTestCase savedTestCase = jiraTestCaseRepository.save(testCase);
+        return convertTestCaseToDto(savedTestCase);
+    }
+
+    // Private helper methods
+
+    /**
+     * Sync Jira issue with database
+     */
+    private JiraIssueDto syncIssueWithDatabase(JiraIssueDto issueDto) {
+        Optional<JiraIssue> existingIssue = jiraIssueRepository.findByJiraKey(issueDto.getJiraKey());
+        
+        JiraIssue issue;
+        if (existingIssue.isPresent()) {
+            // Update existing issue
+            issue = existingIssue.get();
+            updateIssueFromDto(issue, issueDto);
+        } else {
+            // Create new issue
+            issue = createIssueFromDto(issueDto);
+        }
+
+        JiraIssue savedIssue = jiraIssueRepository.save(issue);
+        
+        // Sync linked test cases
+        syncLinkedTestCases(savedIssue, issueDto.getLinkedTestCases());
+        
+        return convertToDto(savedIssue);
+    }
+
+    /**
+     * Update existing issue from DTO
+     */
+    private void updateIssueFromDto(JiraIssue issue, JiraIssueDto issueDto) {
+        issue.setSummary(issueDto.getSummary());
+        issue.setDescription(issueDto.getDescription());
+        issue.setAssignee(issueDto.getAssignee());
+        issue.setAssigneeDisplayName(issueDto.getAssigneeDisplayName());
+        issue.setSprintId(issueDto.getSprintId());
+        issue.setSprintName(issueDto.getSprintName());
+        issue.setIssueType(issueDto.getIssueType());
+        issue.setStatus(issueDto.getStatus());
+        issue.setPriority(issueDto.getPriority());
+    }
+
+    /**
+     * Create new issue from DTO
+     */
+    private JiraIssue createIssueFromDto(JiraIssueDto issueDto) {
+        JiraIssue issue = new JiraIssue();
+        issue.setJiraKey(issueDto.getJiraKey());
+        issue.setSummary(issueDto.getSummary());
+        issue.setDescription(issueDto.getDescription());
+        issue.setAssignee(issueDto.getAssignee());
+        issue.setAssigneeDisplayName(issueDto.getAssigneeDisplayName());
+        issue.setSprintId(issueDto.getSprintId());
+        issue.setSprintName(issueDto.getSprintName());
+        issue.setIssueType(issueDto.getIssueType());
+        issue.setStatus(issueDto.getStatus());
+        issue.setPriority(issueDto.getPriority());
+        return issue;
+    }
+
+    /**
+     * Sync linked test cases
+     */
+    private void syncLinkedTestCases(JiraIssue issue, List<JiraTestCaseDto> testCaseDtos) {
+        // Get existing test cases for this issue
+        Set<String> existingTestCases = issue.getLinkedTestCases().stream()
+                .map(JiraTestCase::getQtestTitle)
+                .collect(Collectors.toSet());
+
+        // Add new test cases
+        for (JiraTestCaseDto testCaseDto : testCaseDtos) {
+            if (!existingTestCases.contains(testCaseDto.getQtestTitle())) {
+                JiraTestCase testCase = new JiraTestCase();
+                testCase.setQtestTitle(testCaseDto.getQtestTitle());
+                testCase.setQtestId(testCaseDto.getQtestId());
+                testCase.setJiraIssue(issue);
+                issue.addLinkedTestCase(testCase);
+            }
+        }
+    }
+
+    /**
+     * Process automation readiness when test case is marked as "Can be Automated"
+     */
+    private void processAutomationReadiness(JiraTestCase jiraTestCase) {
+        logger.info("Processing automation readiness for test case: {}", jiraTestCase.getQtestTitle());
+
+        try {
+            // Check if we have project and tester assignment
+            if (jiraTestCase.getProject() != null && jiraTestCase.getAssignedTester() != null) {
+                
+                // Create or update corresponding TestCase entity
+                TestCase automationTestCase = createOrUpdateAutomationTestCase(jiraTestCase);
+                
+                logger.info("Test case '{}' is ready for automation and assigned to tester: {}", 
+                        jiraTestCase.getQtestTitle(), 
+                        jiraTestCase.getAssignedTester().getName());
+            } else {
+                logger.warn("Test case '{}' marked as automatable but missing project or tester assignment", 
+                        jiraTestCase.getQtestTitle());
+            }
+
+        } catch (Exception e) {
+            logger.error("Error processing automation readiness for test case '{}': {}", 
+                    jiraTestCase.getQtestTitle(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Create or update TestCase entity for automation
+     */
+    private TestCase createOrUpdateAutomationTestCase(JiraTestCase jiraTestCase) {
+        // Check if automation test case already exists
+        List<TestCase> existingTestCases = testCaseService.getAllTestCases()
+                .stream()
+                .filter(tc -> tc.getTitle().equals(jiraTestCase.getQtestTitle()))
+                .collect(Collectors.toList());
+
+        TestCase testCase;
+        if (!existingTestCases.isEmpty()) {
+            // Update existing test case
+            testCase = existingTestCases.get(0);
+            testCase.setStatus("READY_TO_AUTOMATE");
+        } else {
+            // Create new test case
+            testCase = new TestCase();
+            testCase.setTitle(jiraTestCase.getQtestTitle());
+            testCase.setDescription("Test case imported from Jira issue: " + jiraTestCase.getJiraIssue().getJiraKey());
+            testCase.setTestSteps("To be defined during automation implementation");
+            testCase.setExpectedResult("To be defined during automation implementation");
+            testCase.setPriority("Medium");
+            testCase.setStatus("READY_TO_AUTOMATE");
+            testCase.setProject(jiraTestCase.getProject());
+            testCase.setTester(jiraTestCase.getAssignedTester());
+        }
+
+        return testCaseService.createTestCase(testCase);
+    }
+
+    /**
+     * Convert JiraIssue entity to DTO
+     */
+    private JiraIssueDto convertToDto(JiraIssue issue) {
+        JiraIssueDto dto = new JiraIssueDto();
+        dto.setId(issue.getId());
+        dto.setJiraKey(issue.getJiraKey());
+        dto.setSummary(issue.getSummary());
+        dto.setDescription(issue.getDescription());
+        dto.setAssignee(issue.getAssignee());
+        dto.setAssigneeDisplayName(issue.getAssigneeDisplayName());
+        dto.setSprintId(issue.getSprintId());
+        dto.setSprintName(issue.getSprintName());
+        dto.setIssueType(issue.getIssueType());
+        dto.setStatus(issue.getStatus());
+        dto.setPriority(issue.getPriority());
+        dto.setKeywordCount(issue.getKeywordCount());
+        dto.setSearchKeyword(issue.getSearchKeyword());
+        dto.setCreatedAt(issue.getCreatedAt());
+        dto.setUpdatedAt(issue.getUpdatedAt());
+
+        // Convert linked test cases
+        List<JiraTestCaseDto> testCaseDtos = issue.getLinkedTestCases().stream()
+                .map(this::convertTestCaseToDto)
+                .collect(Collectors.toList());
+        dto.setLinkedTestCases(testCaseDtos);
+
+        return dto;
+    }
+
+    /**
+     * Convert JiraTestCase entity to DTO
+     */
+    private JiraTestCaseDto convertTestCaseToDto(JiraTestCase testCase) {
+        JiraTestCaseDto dto = new JiraTestCaseDto();
+        dto.setId(testCase.getId());
+        dto.setQtestTitle(testCase.getQtestTitle());
+        dto.setQtestId(testCase.getQtestId());
+        dto.setCanBeAutomated(testCase.getCanBeAutomated());
+        dto.setCannotBeAutomated(testCase.getCannotBeAutomated());
+        dto.setAutomationStatus(testCase.getAutomationStatus());
+        dto.setAssignedTesterId(testCase.getAssignedTesterId());
+        dto.setDomainMapped(testCase.getDomainMapped());
+        dto.setNotes(testCase.getNotes());
+        dto.setCreatedAt(testCase.getCreatedAt());
+        dto.setUpdatedAt(testCase.getUpdatedAt());
+
+        // Set project information
+        if (testCase.getProject() != null) {
+            dto.setProjectId(testCase.getProject().getId());
+            dto.setProjectName(testCase.getProject().getName());
+        }
+
+        // Set tester information
+        if (testCase.getAssignedTester() != null) {
+            dto.setAssignedTesterName(testCase.getAssignedTester().getName());
+        }
+
+        return dto;
+    }
+}

--- a/src/main/resources/application-jira-template.properties
+++ b/src/main/resources/application-jira-template.properties
@@ -1,0 +1,76 @@
+# ========================================
+# JIRA INTEGRATION CONFIGURATION TEMPLATE
+# ========================================
+# Copy these settings to your application.properties file
+# and replace the placeholder values with your actual Jira details
+
+# Jira Configuration
+# Replace with your Jira instance URL (Cloud or Server)
+jira.url=https://your-company.atlassian.net
+
+# Replace with your Jira username (usually your email for Cloud)
+jira.username=your-email@company.com
+
+# Replace with your Jira API token (for Cloud) or password (for Server)
+# For Cloud: Get token from https://id.atlassian.com/manage-profile/security/api-tokens
+jira.token=your-api-token-here
+
+# Replace with your Jira project key (visible in issue keys like PROJ-123)
+jira.project.key=PROJ
+
+# Replace with your Jira board ID (found in board URL)
+# Example: https://your-company.atlassian.net/jira/software/projects/PROJ/boards/123
+# The board ID would be 123
+jira.board.id=123
+
+# QTest Configuration (Optional - for future QTest integration)
+# Replace with your QTest instance details if you use QTest
+qtest.url=https://your-company.qtestnet.com
+qtest.username=your-qtest-username
+qtest.token=your-qtest-api-token
+
+# ========================================
+# HOW TO FIND YOUR CONFIGURATION VALUES
+# ========================================
+
+# 1. JIRA URL:
+#    - For Cloud: https://your-company.atlassian.net
+#    - For Server: https://jira.your-company.com
+
+# 2. JIRA USERNAME:
+#    - For Cloud: Your email address
+#    - For Server: Your username
+
+# 3. JIRA API TOKEN:
+#    - For Cloud: Create at https://id.atlassian.com/manage-profile/security/api-tokens
+#    - For Server: Your password or API token
+
+# 4. PROJECT KEY:
+#    - Look at any issue in your project
+#    - Example: If issues are like "MYPROJ-123", the key is "MYPROJ"
+
+# 5. BOARD ID:
+#    - Go to your board in Jira
+#    - Look at the URL: .../boards/123 - the number is your board ID
+#    - Or use Jira REST API: GET /rest/agile/1.0/board
+
+# ========================================
+# TESTING YOUR CONFIGURATION
+# ========================================
+# After setting up, test your configuration by:
+# 1. Starting your application
+# 2. Making a GET request to: http://localhost:8000/api/manual-page/test-connection
+# 3. You should see: {"connected": true, "message": "Successfully connected to Jira"}
+
+# ========================================
+# SECURITY NOTES
+# ========================================
+# - Never commit actual credentials to version control
+# - Use environment variables for production:
+#   jira.url=${JIRA_URL}
+#   jira.username=${JIRA_USERNAME}
+#   jira.token=${JIRA_TOKEN}
+#   jira.project.key=${JIRA_PROJECT_KEY}
+#   jira.board.id=${JIRA_BOARD_ID}
+
+# - For Docker deployments, use Docker secrets or environment files

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,18 @@ jenkins.url=https://jenkinsautoqa.winwholesale.com/jenkins/
 jenkins.username=gsamota
 jenkins.token=Win@gsupply1321
 
+# Jira Configuration
+jira.url=
+jira.username=
+jira.token=
+jira.project.key=
+jira.board.id=
+
+# QTest Configuration  
+qtest.url=
+qtest.username=
+qtest.token=
+
 
 # JPA Configuration
 


### PR DESCRIPTION
Add backend for the Manual Page feature, integrating with Jira to manage test case automation readiness and keyword search.

---

[Open in Web](https://www.cursor.com/agents?id=bc-9cf38b23-d1bb-4205-8b3e-cab9769eeeb7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9cf38b23-d1bb-4205-8b3e-cab9769eeeb7)